### PR TITLE
Implement chat handover and end chat functionality

### DIFF
--- a/app/(app)/(student)/selectMentor.jsx
+++ b/app/(app)/(student)/selectMentor.jsx
@@ -7,8 +7,12 @@ import Carousel from 'react-native-reanimated-carousel';
 import { heightPercentageToDP as hp, widthPercentageToDP as wp } from 'react-native-responsive-screen';
 import MentorCard from '../../../components/MentorCard';
 import { useUserList } from '../../../context/userListProvider';
+import { useLocalSearchParams } from 'expo-router';
 
 const SelectMentor = () => {
+
+  const { fromRoom, keepChat } = useLocalSearchParams();
+
   const { mentors } = useUserList();
 
   const [isFilterVisible, setFilterVisible] = useState(false);
@@ -36,7 +40,7 @@ const SelectMentor = () => {
       {/* Carousel */}
       <Carousel
         data={filteredMentors}
-        renderItem={({ item }) => <MentorCard mentor={item} />}
+        renderItem={({ item }) => <MentorCard mentor={item} fromRoom={fromRoom} keepChat={keepChat}/>}
         pagingEnabled
         snapEnabled
         slideStyle={{ overflow: 'visible' }}

--- a/components/MentorCard.js
+++ b/components/MentorCard.js
@@ -4,7 +4,7 @@ import { useRouter } from 'expo-router';
 import { Image, Text, TouchableOpacity, View } from 'react-native';
 import { heightPercentageToDP as hp, widthPercentageToDP as wp } from 'react-native-responsive-screen';
 
-const MentorCard = ({mentor}) => {
+const MentorCard = ({mentor, fromRoom, keepChat}) => {
   // Calculating by academic year
   const currentDate = new Date();
   const currentYear = currentDate.getFullYear();
@@ -21,7 +21,9 @@ const MentorCard = ({mentor}) => {
   const handleChatNow = () => {
     router.replace({pathname: '/chatRoom', params: {
       ...mentor,
-      profileUrl: encodeURIComponent(mentor.profileUrl)
+      profileUrl: encodeURIComponent(mentor.profileUrl),
+      fromRoom,
+      keepChat,
     }});     
   }
 

--- a/components/MessageItem.js
+++ b/components/MessageItem.js
@@ -52,10 +52,43 @@ const MessageItem = ({message, currentUser, otherUserId, lastSeen}) => {
             </View>
         </View>
     )
-  } else {
+  } else if (otherUserId === message?.userId) {
     return (
         <View style={{width: wp(80)}} className='ml-3 mb-2'>
             <View className='flex self-start p-3 px-4 rounded-2xl bg-white border-neutral-200 border'>
+                <Text style={{fontSize: hp(2)}}>
+                    {message?.text}
+                </Text>
+                <Text style={{ fontSize: hp(1.3), color: '#666', marginTop: 4, alignSelf: 'flex-end' }}>
+                    {time}
+                </Text>
+            </View>
+        </View>
+    )
+  } else if (message.type !== 'system' && currentUser.role === 'mentor') {
+    return (
+        <View className='flex-row justify-end mb-2 mr-3'>
+            <View style={{width: wp(80)}}>
+                <View className='flex self-end p-3 rounded-2xl bg-neutral-200 border border-indigo-200'>
+                    <Text style={{fontSize: hp(2)}}>
+                        {message?.text}
+                    </Text>
+                    <View className='flex-row items-center justify-end mt-1 gap-1'>
+                        <Text style={{ fontSize: hp(1.3), color: '#666'}}>
+                            {time}
+                        </Text>
+                        <Animated.View style={animatedStyle}>
+                            <MaterialCommunityIcons name={isRead ? 'check-all' : 'check-underline'} color={'#666'} size={hp(1.3)}/>
+                        </Animated.View>
+                    </View>
+                </View>
+            </View>
+        </View>
+    )
+  } else if (message.type !== 'system' && currentUser.role === 'student') {
+    return (
+        <View style={{width: wp(80)}} className='ml-3 mb-2'>
+            <View className='flex self-start p-3 px-4 rounded-2xl bg-neutral-200 border-neutral-200 border'>
                 <Text style={{fontSize: hp(2)}}>
                     {message?.text}
                 </Text>

--- a/components/MessageList.js
+++ b/components/MessageList.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { ScrollView } from 'react-native'
 import MessageItem from './MessageItem'
 
-const MessageList = ({messages, currentUser, scrollViewRef, otherUserId, lastSeen}) => {
+const MessageList = ({messages, currentUser, scrollViewRef, otherUserId, lastSeen, isActive, chatEndDate}) => {
   return (
     <ScrollView ref={scrollViewRef} showsVerticalScrollIndicator={false} contentContainerStyle={{paddingTop: 10}}>
       {
@@ -23,10 +23,29 @@ const MessageList = ({messages, currentUser, scrollViewRef, otherUserId, lastSee
                 </Text>
               </View>
             )}
+            {
+              message.type === 'system' && (
+                <View className="items-center mb-3">
+                  <Text className="text-xs text-neutral-500 bg-neutral-200 px-4 py-1 rounded-full">
+                    🔔 This is the beginning of your new chat.
+                  </Text>
+                </View>
+              )
+            }
               <MessageItem message={message} key={index} currentUser={currentUser} otherUserId={otherUserId} lastSeen={lastSeen}/>
             </View>
           )
         })
+      }
+      {
+        !isActive && (
+          <View className="items-center mb-3 pb-5">
+            <Text className="text-xs text-neutral-500 bg-neutral-200 px-4 py-1 rounded-full text-center">
+              Chat has ended on {chatEndDate.toDate().toLocaleString() + '.\n'}
+              Messages will be deleted after 3 days.
+            </Text>
+          </View>
+        )
       }
     </ScrollView>
   )


### PR DESCRIPTION
- Added support for chat handover with and without retaining message history
- Implemented UI pills to indicate end of old chat and start of new chat
- Colour coded messages from previous mentor when history is retained
- Developed "End chat" flow with inactive status and timestamp in Firestore
- Users can still view inactive chats; chat input and header icons are hidden
- Set up Cloud Function to auto-delete inactive chats after 3 days using hourly index checks