### PR TITLE
Implement mentor account deletion flow

### DIFF
--- a/app/(app)/(admin)/(tabs)/_layout.jsx
+++ b/app/(app)/(admin)/(tabs)/_layout.jsx
@@ -1,12 +1,29 @@
 import { View, Text } from 'react-native'
 import React from 'react'
 import { Stack, Tabs } from 'expo-router'
+import HomeHeader from '../../../../components/HomeHeader'
+import { Feather, Ionicons } from '@expo/vector-icons'
+import {widthPercentageToDP as wp, heightPercentageToDP as hp} from 'react-native-responsive-screen';
 
 const AdminTabLayout = () => {
   return (
-    <Tabs>
-      <Tabs.Screen name='home' options={{headerShown: false}} />
-      <Tabs.Screen name='addMentor' options={{headerShown: false}} />
+    <Tabs screenOptions={{animation: 'fade'}}>
+      <Tabs.Screen name='home' options={{
+        header: () => <HomeHeader/>,
+        title: 'Home',
+        tabBarIcon: ({focused}) => (
+          <Ionicons size={hp(2)}
+            name={focused? 'home' : 'home-outline'}
+            color={'#6366F1'}
+          />
+        )}} />
+      <Tabs.Screen name='mentorList' options={{
+        header: () => <HomeHeader/>,
+        title: 'Dashboard',
+        tabBarIcon: ({focused}) => (
+          <Ionicons size={hp(2)} name={focused? 'list' : 'list-outline'} color={'#6366F1'}/>
+        )
+      }}/>
     </Tabs>
   )
 }

--- a/app/(app)/(admin)/(tabs)/mentorList.jsx
+++ b/app/(app)/(admin)/(tabs)/mentorList.jsx
@@ -1,0 +1,47 @@
+import { View, Text, TouchableOpacity, FlatList } from 'react-native'
+import React from 'react'
+import {widthPercentageToDP as wp, heightPercentageToDP as hp} from 'react-native-responsive-screen';
+import { useRouter } from 'expo-router';
+import { useUserList } from '../../../../context/userListProvider';
+import { Image } from 'expo-image';
+import { blurhash } from '../../../../components/common';
+
+const MentorList = () => {
+
+    const router = useRouter();
+    const { mentors } = useUserList();    
+
+  return (
+    <View className='flex-1 bg-white p-5'>
+      <TouchableOpacity onPress={() => router.push('/addMentor')} className='bg-emerald-400 rounded-xl p-3 items-center mb-3'>
+        <Text className='font-semibold text-white' style={{fontSize: hp(2)}}>Add new mentor</Text>
+      </TouchableOpacity>
+
+      <FlatList
+        data={mentors}
+        keyExtractor={item => Math.random()}
+        showsVerticalScrollIndicator={false}
+        renderItem={({item, index}) => 
+            <TouchableOpacity
+                onPress={() => router.push({pathname: '/editMentor', params: {...item, profileUrl: encodeURIComponent(item.profileUrl)}})}
+                className={`flex-row justify-start mx-4 items-center gap-5 mb-4 pb-2 
+                    ${index + 1 === mentors.length ? "" : "border-b border-b-neutral-200"}`}
+            >
+                <Image 
+                    style={{ height: hp(6), width: hp(6), borderRadius: 100 }}
+                    source={item?.profileUrl}
+                    placeholder={blurhash}
+                    transition={500}
+                />
+
+                <Text className='font-medium' style={{fontSize: hp(1.5)}}>
+                    {item?.username}
+                </Text>
+            </TouchableOpacity>
+        }
+      />
+    </View>
+  )
+}
+
+export default MentorList

--- a/app/(app)/(admin)/addMentor.jsx
+++ b/app/(app)/(admin)/addMentor.jsx
@@ -3,9 +3,9 @@ import React, { useRef, useState } from 'react'
 import {widthPercentageToDP as wp, heightPercentageToDP as hp} from 'react-native-responsive-screen';
 import { Feather, Ionicons, Octicons } from '@expo/vector-icons';
 import { useRouter } from 'expo-router';
-import CustomKeyboardView from '../../../../components/CustomKeyboardView';
-import {useAuth} from '../../../../context/authContext';
-import Loading from '../../../../components/Loading';
+import CustomKeyboardView from '../../../components/CustomKeyboardView';
+import {useAuth} from '../../../context/authContext';
+import Loading from '../../../components/Loading';
 import { Dropdown } from 'react-native-element-dropdown';
 
 const genderOptions = [
@@ -40,10 +40,6 @@ const AddMentor = () => {
   const dobRef = useRef("");
   const matricYearRef = useRef("");
 
-  const handleLogout = async () => {
-      await logout();
-  }
-
   const handleRegister = async () => {
     if(!emailRef.current || !facultyRef.current || !usernameRef.current || !genderRef.current || !dobRef.current || !matricYearRef.current){
       console.log('Email: ', emailRef.current);
@@ -77,8 +73,8 @@ const AddMentor = () => {
       <StatusBar style='dark' />
       <View style={{paddingTop: hp(7), paddingHorizontal: wp(5)}} className='flex-1 gap-12 bg-white'>
         {/* SignIn Image */}
-        <View className='items-center'>
-          <Image style={styles.logo} source={require('../../../../assets/images/HappiNUS2.png')}/>
+        <View className='items-center -m-10'>
+          <Image style={styles.logo} source={require('../../../assets/images/HappiNUS2.png')}/>
         </View>
 
         <View className='gap-8'>
@@ -133,15 +129,7 @@ const AddMentor = () => {
                   </Text>
                 </TouchableOpacity>
               )}
-            </View>
-            
-            {/* Temp Sign Out */}
-            <View className='flex-row justify-center'>
-              <Pressable onPress={handleLogout}>
-                <Text style={{fontSize: hp(1.8)}} className='font-bold text-indigo-500'>Sign Out</Text>
-              </Pressable>
-            </View>
-
+            </View>   
           </View>
         </View>
       </View>

--- a/app/(app)/(admin)/editMentor.jsx
+++ b/app/(app)/(admin)/editMentor.jsx
@@ -1,0 +1,102 @@
+import { View, Text, TouchableOpacity, Alert } from 'react-native'
+import React from 'react'
+import { useLocalSearchParams, useRouter } from 'expo-router'
+import {widthPercentageToDP as wp, heightPercentageToDP as hp} from 'react-native-responsive-screen';
+import { addDoc, collection, deleteDoc, doc, getDocs, query, Timestamp, updateDoc, where } from 'firebase/firestore';
+import { db, functions } from '../../../firebaseConfig';
+import { getStorage, ref, deleteObject } from 'firebase/storage';
+import { httpsCallable } from 'firebase/functions';
+
+const EditMentor = () => {
+
+    const mentor = useLocalSearchParams();
+    const router = useRouter();
+
+    const handleDelete = () => {
+        Alert.alert('Delete Confirmation', 'Are you sure you want to proceed? This action cannot be undone.', [{
+            text:'Dismiss'
+        }, {
+            text: 'Proceed',
+            onPress: () => proceedWithDeletion()
+        }])
+    }
+
+    const proceedWithDeletion = async () => {
+        try {
+            const roomQuery = query(collection(db, 'rooms'), 
+                where('participants', 'array-contains', mentor.userId),
+                where('active', '==', true));
+
+            const roomSnap = await getDocs(roomQuery);
+
+            if (!roomSnap.empty) {
+                Alert.alert('Mentor has Active Chats', 
+                    `Mentor is currently in ${roomSnap.size} active chat${roomSnap.size > 1 ? 's' : ''}. Proceeding will end all of them.`,
+                    [{
+                        text: 'Cancel'
+                    }, {
+                        text: 'Proceed Anyway',
+                        onPress: () => handleForceDelete(roomSnap.docs, mentor.userId)
+                    }]
+                );
+            } else {
+                console.log('mentor has no active chats');
+                
+                await callDeleteMentor(mentor.userId);
+            }
+        } catch (error) {
+            console.error('Error checking mentor chats: ', error);
+            Alert.alert('Error', 'Could not complete deletion');
+        }
+    }
+
+    const handleForceDelete = async (docs, mentorId) => {
+        try {
+            for (const docSnap of docs){
+                const roomRef = doc(db, 'rooms', docSnap.id);
+                await updateDoc(roomRef, {
+                    active: false // Don't set inactiveOn to allow student to retain the chatroom until student initiates handover
+                });
+
+                const msgRef = collection(roomRef, 'messages');
+                await addDoc(msgRef, {
+                    type: 'system',
+                    subType: 'removed',
+                    text: `⚠️ This mentor is no longer available as their account has been removed by an admin.${'\n'}Please select a new mentor to continue, or end the chat if you wish.`,
+                    createdAt: Timestamp.now(),
+                    senderName: 'system'
+                });
+            }
+
+            await callDeleteMentor(mentorId);
+        } catch (error) {
+            console.error('Error ending mentor chats: ', error);
+            Alert.alert('Error', 'Failed to clean up mentor chats.');
+        }
+    }
+
+    const callDeleteMentor = async (mentorId) => {
+        try {
+            const deleteMentor = httpsCallable(functions, 'deleteAccount');
+            const result = await deleteMentor({userId: mentorId});
+
+            if (result.data.success) {
+                Alert.alert('Success', result.data.message);
+                router.back();
+            }
+        } catch (error) {
+            console.error('Mentor deletion error: ', error);
+            Alert.alert('Error', error?.message || 'Failed to delete mentor.');
+        }
+    }
+
+  return (
+    <View className='flex-1 bg-white p-5'>
+      <TouchableOpacity onPress={handleDelete} className='bg-rose-400 rounded-xl p-3 justify-center items-center'>
+        <Text className='font-semibold text-white' style={{fontSize: hp(2)}}>Delete mentor</Text>
+      </TouchableOpacity>
+    </View>
+  )
+}
+
+export default EditMentor

--- a/app/(app)/(shared)/chatRoom.jsx
+++ b/app/(app)/(shared)/chatRoom.jsx
@@ -95,6 +95,9 @@ const ChatRoom = () => {
 
                 oldMessagesSnap.forEach((message) => {
                     const data = message.data();
+
+                    if (data?.subType === 'removed') return;
+
                     const isPrevMentor = data.userId !== item.userId && data.userId !== user.userId;
 
                     batch.set(doc(db, 'rooms', roomId, 'messages', message.id), {
@@ -104,8 +107,9 @@ const ChatRoom = () => {
                 });
 
                 batch.set(doc(db, 'rooms', roomId, 'messages', 'sys-divider'), {
-                    text: 'This chat has been handed over sucessfully 😊',
+                    text: `This chat has been handed over successfully 😊.${'\n'}This is the beginning of your new chat`,
                     type: 'system',
+                    subType: 'handover',
                     createdAt: Timestamp.now()
                 });
 
@@ -174,7 +178,7 @@ const ChatRoom = () => {
     <CustomKeyboardView inChat={true}>
         <View className='flex-1'>
             <StatusBar style='dark' />
-            <ChatRoomHeader user={{...item, profileUrl: encodeURIComponent(item.profileUrl)}} roomId={roomId} messages={messages} textRef={textRef} inputRef={inputRef} isActive={isActive}/>
+            <ChatRoomHeader user={{...item, profileUrl: encodeURIComponent(item.profileUrl)}} roomId={roomId} messages={messages} textRef={textRef} inputRef={inputRef} isActive={isActive} chatEndDate={chatEndDate}/>
             <View className='h-1 border-b border-neutral-300' />
             <View className='flex-1 justify-between bg-neutral-100 overflow-visible'>
                 <View className='flex-1'>

--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -31,7 +31,7 @@ const MainLayout = () => {
       else if (role === 'mentor')
         router.replace('/(app)/(mentor)/(tabs)/home');
       else if (role === 'admin')
-        router.replace('/(app)/(admin)/(tabs)/addMentor');
+        router.replace('/(app)/(admin)/(tabs)/home');
     } else if (!isAuthenticated && !isAuthPage){
       // Redirect to Sign in
       router.replace('/signIn');

--- a/components/ChatRoomHeader.js
+++ b/components/ChatRoomHeader.js
@@ -10,7 +10,7 @@ import Loading from './Loading';
 import { doc, Timestamp, updateDoc } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
 
-const ChatRoomHeader = ({user, roomId, messages, textRef, inputRef, isActive}) => {
+const ChatRoomHeader = ({user, roomId, messages, textRef, inputRef, isActive, chatEndDate}) => {
 
     const [summaryLoading, setSummaryLoading] = useState(false);
     const [rephraseLoading, setRephraseLoading] = useState(false);
@@ -182,7 +182,7 @@ const ChatRoomHeader = ({user, roomId, messages, textRef, inputRef, isActive}) =
                 </View>
             ),
             headerRight: () => {
-                if (!isActive) return null;
+                if (!isActive && chatEndDate) return null;
 
                 if (user?.role === 'student') {
                 return (

--- a/components/MessageList.js
+++ b/components/MessageList.js
@@ -4,6 +4,8 @@ import { ScrollView } from 'react-native'
 import MessageItem from './MessageItem'
 
 const MessageList = ({messages, currentUser, scrollViewRef, otherUserId, lastSeen, isActive, chatEndDate}) => {
+  console.log(otherUserId);
+  
   return (
     <ScrollView ref={scrollViewRef} showsVerticalScrollIndicator={false} contentContainerStyle={{paddingTop: 10}}>
       {
@@ -26,8 +28,8 @@ const MessageList = ({messages, currentUser, scrollViewRef, otherUserId, lastSee
             {
               message.type === 'system' && (
                 <View className="items-center mb-3">
-                  <Text className="text-xs text-neutral-500 bg-neutral-200 px-4 py-1 rounded-full">
-                    🔔 This is the beginning of your new chat.
+                  <Text className="text-xs text-neutral-500 bg-neutral-200 px-4 py-1 rounded-full mx-2 text-center">
+                    {message.text}
                   </Text>
                 </View>
               )
@@ -38,7 +40,7 @@ const MessageList = ({messages, currentUser, scrollViewRef, otherUserId, lastSee
         })
       }
       {
-        !isActive && (
+        !isActive && chatEndDate && (
           <View className="items-center mb-3 pb-5">
             <Text className="text-xs text-neutral-500 bg-neutral-200 px-4 py-1 rounded-full text-center">
               Chat has ended on {chatEndDate.toDate().toLocaleString() + '.\n'}

--- a/context/userListProvider.js
+++ b/context/userListProvider.js
@@ -40,7 +40,13 @@ export const UserListProvider = ({ children }) => {
     const usersProfiles = await Promise.all(
       otherUserIds.map(async (uid) => {
         const userDoc = await getDoc(doc(db, 'users', uid));
-        return userDoc.exists() ? userDoc.data() : null;
+        return userDoc.exists() ? userDoc.data() : {
+          username: 'Account Deleted',
+          userId: uid,
+          profileUrl: 'https://firebasestorage.googleapis.com/v0/b/happinus-ba24a.firebasestorage.app/o/profilePictures%2Fsmile.jpg?alt=media&token=54944b3f-caa7-4066-b8e1-784d4c341b23',
+          role: 'mentor',
+          deleted: true
+        };
       })
     );
 

--- a/firebaseConfig.js
+++ b/firebaseConfig.js
@@ -5,6 +5,7 @@ import { getApp, getApps, initializeApp } from "firebase/app";
 import { getAuth, getReactNativePersistence, initializeAuth } from 'firebase/auth'
 import AsyncStorage from "@react-native-async-storage/async-storage";
 import { getFirestore, collection} from 'firebase/firestore'
+import { getFunctions } from 'firebase/functions'
 
 // Your web app's Firebase configuration
 const firebaseConfig = {
@@ -28,3 +29,4 @@ export const auth = initializeAuth(app, {
 export const db = getFirestore(app);
 export const usersRef = collection(db, 'users');
 export const roomRef = collection(db, 'rooms');
+export const functions = getFunctions(app);


### PR DESCRIPTION
- Checked for active chats before deletion; marked them as inactive without setting inactiveOn
Created Cloud Function to:
- Delete mentor from Firestore ('users' collection)
- Remove profile picture from Firebase Storage
- Delete user from Firebase Authentication
Added system message pill in chats to inform students of mentor deletion
Enabled students to initiate chat handover (retain/forgo messages) or end chat
inactiveOn is only set when student takes action, triggering 3-day auto-deletion countdown
Updated deleted mentor's profile to default image and 'Account deleted' name
Known issue: Admin gets logged in as newly created mentor (to be fixed later)